### PR TITLE
edit event now only updates the title

### DIFF
--- a/server/controllers/editEventController.js
+++ b/server/controllers/editEventController.js
@@ -30,7 +30,7 @@ const EventsRef = dbRef.child('events');
 //THIS IMPLEMENTATION WORKS, BUT ONLY WITH DUMMY DATA
 //SPECIFICALLY THE CHILD ID FIELD IS DRAWING FROM HARD COPY FROM DB
 exports.editEvent = function(req, res) {
-		EventsRef.child('-L-hHjkRMsleNYb-aBwS').update({eventName: 'FUCK YOU I WORK'})
+		EventsRef.child('-L-hHjkRMsleNYb-aBwS').update({eventName: req.body.eventName})
 	.then(editedEvent => {
 	 console.log('successfully changed event in DB')
 	 Promise.resolve(editedEvent)


### PR DESCRIPTION
and takes in the new event name passed from the edit event form. not a lewd string I forgot to get rid of.